### PR TITLE
OS X compatibility

### DIFF
--- a/zerkenv
+++ b/zerkenv
@@ -466,7 +466,10 @@ $name() {
   if $newshell; then
     eval "( $name $* ; exec $BASH )"
   else
-    . <(colors=true $prog -d "$@")
+    local ZERKENV_TEMPFILE=$(mktemp)
+    colors=true $prog -d "$@" > $ZERKENV_TEMPFILE
+    . $ZERKENV_TEMPFILE
+    rm $ZERKENV_TEMPFILE
   fi
 }
 _$prog() {

--- a/zerkenv
+++ b/zerkenv
@@ -453,10 +453,11 @@ install_bash() {
   cat <<'EOT' |envsubst '$prog $name'
 $name() {
   local OPTIND OPTARG o newshell=false
-  while getopts "hn" o; do
+  while getopts "hnv" o; do
     case "${o}" in
       h) echo "USAGE: $name [-hn] <module>..." ; return ;;
       n) newshell=true ;;
+      v) set -xf ;;
       ?) return 1 ;;
     esac
   done
@@ -512,7 +513,7 @@ opt_update_cache=false
 opt_delete_cache=false
 opt_delete_s3=false
 
-while getopts "cdhi:lruw:W:x:X:" o; do
+while getopts "cdhi:lruw:W:x:X:v" o; do
   case "${o}" in
     c) opt_completions=true ; break ;;
     d) opt_resolve_deps=true ; break ;;
@@ -525,6 +526,7 @@ while getopts "cdhi:lruw:W:x:X:" o; do
     W) put_s3 $OPTARG ; exit $? ;;
     x) opt_delete_cache=true ; : $((OPTIND--)) ; break ;;
     X) opt_delete_s3=true ; : $((OPTIND--)) ; break ;;
+    v) set -xv ; break ;;
     ?) exit 1 ;;
   esac
 done

--- a/zerkenv
+++ b/zerkenv
@@ -353,12 +353,12 @@ get_cache_or_s3() {
 }
 
 update_cache() {
-  local module found modules="$@" local_modules=$(ls_cache) remote_modules
+  local module found local_modules=$(ls_cache) remote_modules
   remote_modules=$(ls_s3)
   if [ $# -eq 0 ]; then
     modules=$(sort <(echo "$remote_modules") <(echo "$local_modules") |uniq -d)
   fi
-  for module in $modules; do
+  for module in "$@"; do
     found=$(sort <(echo "$module") <(echo "$remote_modules") |uniq -d)
     if ! not_private $module; then
       warn "* $module is private so cannot be updated from S3"
@@ -372,9 +372,9 @@ update_cache() {
 }
 
 rm_cache() {
-  local modules module file
-  modules="$@"
-  for module in "$modules"; do
+  local module file
+
+  for module in "$@"; do
     file=$(cache_file $module)
     if [ -f "$file" ]; then
       info "* $module"
@@ -386,10 +386,9 @@ rm_cache() {
 }
 
 rm_s3() {
-  local modules module file
-  modules="$@"
+  local module file
   assert_s3
-  for module in "$modules"; do
+  for module in "$@"; do
     file=$(s3_file $module)
     if aws s3 rm "$file" --region $ZERKENV_REGION; then
       info "* $module"
@@ -400,10 +399,9 @@ rm_s3() {
 }
 
 resolve_dependencies_impl() {
-  local modules deps module ZERKENV_DEPENDENCIES MODULE_LIST
-  modules="$@"
+  local deps module ZERKENV_DEPENDENCIES
 
-  for module in $modules; do
+  for module in "$@"; do
     ZERKENV_MODULE_TEMP=$(mktemp)
     get_cache_or_s3 $module > $ZERKENV_MODULE_TEMP
     source $ZERKENV_MODULE_TEMP

--- a/zerkenv
+++ b/zerkenv
@@ -372,8 +372,9 @@ update_cache() {
 }
 
 rm_cache() {
-  local module file
-  for module in "$@"; do
+  local modules module file
+  modules="$@"
+  for module in "$modules"; do
     file=$(cache_file $module)
     if [ -f "$file" ]; then
       info "* $module"
@@ -385,9 +386,10 @@ rm_cache() {
 }
 
 rm_s3() {
-  local module file
+  local modules module file
+  modules="$@"
   assert_s3
-  for module in "$@"; do
+  for module in "$modules"; do
     file=$(s3_file $module)
     if aws s3 rm "$file" --region $ZERKENV_REGION; then
       info "* $module"
@@ -398,21 +400,26 @@ rm_s3() {
 }
 
 resolve_dependencies_impl() {
-  local deps module ZERKENV_DEPENDENCIES
+  local modules deps module ZERKENV_DEPENDENCIES MODULE_LIST
+  modules="$@"
 
-  for module in "$@"; do
-    . <(get_cache_or_s3 $module)
+  for module in $modules; do
+    ZERKENV_MODULE_TEMP=$(mktemp)
+    get_cache_or_s3 $module > $ZERKENV_MODULE_TEMP
+    source $ZERKENV_MODULE_TEMP
+    rm $ZERKENV_MODULE_TEMP
+
     for dep in $module $ZERKENV_DEPENDENCIES; do
       deps="$deps $dep $module"
     done
     ZERKENV_DEPENDENCIES=
   done
 
-  echo "$deps" |tsort
+  echo "$deps" |tsort | sort
 }
 
 resolve_dependencies() {
-  local i deps prev=$(for i in "$@"; do echo $i; done)
+  local i deps prev=$(for i in "$@"; do echo $i; done | sort)
 
   export ZERKENV_RESOLVING_DEPENDENCIES=true
   while true; do


### PR DESCRIPTION
This doesn't fix everything. `zerkenv module1 module2` still chokes. But it basically works. I have this in my `.bashrc`, since the same problem this patch fixes means you can't do `. <(zerkenv -i bash)`.

```
    ZERKENV_SH_TEMP=$(mktemp)
    zerkenv -i bash > $ZERKENV_SH_TEMP
    source $ZERKENV_SH_TEMP
    rm $ZERKENV_SH_TEMP
```